### PR TITLE
chore(service-layer): harden PlanItemService tests + CI ordering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,10 @@ jobs:
           echo "API_URL=http://127.0.0.1:54321" >> $GITHUB_ENV
           test -n "$ANON" || (echo "anon_key missing" && exit 1)
 
+      - name: Run Service Layer Tests
+        run: |
+          deno test --allow-env --allow-net tests/service/
+
       - name: Smoke Test (Edge Function)
         run: |
           # Use Deno to run smoke test script

--- a/engine/src/services/planItemService.ts
+++ b/engine/src/services/planItemService.ts
@@ -22,6 +22,7 @@ export class PlanItemService {
         // Validate inputs (Basic boundary validation)
         if (!item.plan_id) throw new Error("plan_id is required");
         if (!item.meal_id) throw new Error("meal_id is required");
+        if (!item.meal_type) throw new Error("meal_type is required");
 
         const { data, error } = await this.supabase.rpc("insert_plan_item", {
             p_plan_id: item.plan_id,

--- a/tests/service/planItemService_test.ts
+++ b/tests/service/planItemService_test.ts
@@ -3,51 +3,79 @@ import { assertEquals, assertRejects } from "https://deno.land/std@0.168.0/testi
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.38.4";
 import { PlanItemService } from "../../engine/src/services/planItemService.ts";
 
-const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "http://localhost:54321";
-const supabaseKey = Deno.env.get("SUPABASE_ANON_KEY") ?? "anon-key-placeholder";
+/**
+ * FakeSupabaseClient implements a minimal in-memory version of Supabase client behavior
+ * required for PlanItemService. This avoids network calls and flaky mocks.
+ */
+class FakeSupabaseClient {
+    // Stores RPC calls for verification if needed, or mimics state
+    // For this service, we just need to return success/fail based on input
 
-Deno.test("PlanItemService - insertPlanItem - Integration Mock", async () => {
-    // This test actually connects to the DB if available, or mocks check
-    // Since we are in an environment where we might check only logic if DB not present
-    // But acceptance criteria requires "Unit/integration test or validator hook"
-
-    // We'll create a mock client to verify the method calls RPC correctly
-    // or skip if we can't fully mock. 
-    // Ideally we want to hit the real DB in CI.
-
-    // Simple Mock for unit testing behavior
-    const mockSupabase = {
-        rpc: (name: string, args: any) => {
-            if (name === "insert_plan_item") {
-                if (args.p_plan_id === "fail") return Promise.resolve({ data: null, error: { message: "Simulated Failure" } });
-                return Promise.resolve({ data: "generated-uuid-123", error: null });
+    rpc(name: string, args: any) {
+        if (name === "insert_plan_item") {
+            // Simulate backend validation logic locally
+            if (!args.p_plan_id || !args.p_meal_type || !args.p_meal_id) {
+                return Promise.resolve({ data: null, error: { message: "Invalid RPC Arguments" } });
             }
-            return Promise.resolve({ data: null, error: { message: "Unknown RPC" } });
+
+            // Simulate successful insertion returning a UUID
+            // Deterministic UUID-like string for testing
+            return Promise.resolve({ data: "12345678-1234-4444-8888-1234567890ab", error: null });
         }
-    } as any;
+        return Promise.resolve({ data: null, error: { message: `Function ${name} not found` } });
+    }
+}
 
-    const service = new PlanItemService(mockSupabase);
+Deno.test("PlanItemService - insertPlanItem - with FakeClient", async (t) => {
+    const fakeClient = new FakeSupabaseClient() as any;
+    const service = new PlanItemService(fakeClient);
 
-    const id = await service.insertPlanItem({
-        plan_id: "test-plan",
-        day_of_week: 1,
-        meal_type: "lunch",
-        meal_id: "meal-1",
-        is_consumed: false
+    await t.step("should call RPC and return ID on valid input", async () => {
+        const id = await service.insertPlanItem({
+            plan_id: "plan-1",
+            day_of_week: 1,
+            meal_type: "breakfast",
+            meal_id: "meal-1",
+            is_consumed: false
+        });
+
+        assertEquals(id, "12345678-1234-4444-8888-1234567890ab");
     });
 
-    assertEquals(id, "generated-uuid-123");
+    await t.step("should throw validation error if plan_id missing", async () => {
+        await assertRejects(
+            async () => {
+                await service.insertPlanItem({
+                    plan_id: "",
+                    day_of_week: 1,
+                    meal_type: "breakfast",
+                    meal_id: "meal-1"
+                });
+            },
+            Error,
+            "plan_id is required"
+        );
+    });
 
-    await assertRejects(
-        async () => {
-            await service.insertPlanItem({
-                plan_id: "fail", // Triggers mock failure
-                day_of_week: 1,
-                meal_type: "lunch",
-                meal_id: "meal-1"
-            });
-        },
-        Error,
-        "RPC insert_plan_item failed"
-    );
+    await t.step("should throw RPC error if client returns error", async () => {
+        // Create a client that always fails RPC
+        const errorClient = {
+            rpc: () => Promise.resolve({ data: null, error: { message: "DB Error" } })
+        } as any;
+
+        const failService = new PlanItemService(errorClient);
+
+        await assertRejects(
+            async () => {
+                await failService.insertPlanItem({
+                    plan_id: "plan-1",
+                    day_of_week: 1,
+                    meal_type: "breakfast",
+                    meal_id: "meal-1"
+                });
+            },
+            Error,
+            "RPC insert_plan_item failed: DB Error"
+        );
+    });
 });


### PR DESCRIPTION
## NEDEN

Bu PR, Phase 1.5 service layer hardening çalışmasının bir parçasıdır. PlanItemService için:
- Input validation boundary'leri eklendi (plan_id, meal_id, meal_type için required field kontrolü)
- Test dosyası Fake client pattern'ine geçirildi (daha güvenilir ve izole testler)
- CI workflow'da test sıralaması düzenlendi (Service Layer Tests eklendi)

## Değişen Dosyalar

- `.github/workflows/ci.yml` - Service Layer Tests step'i eklendi
- `engine/src/services/planItemService.ts` - Input validation boundary'leri eklendi
- `tests/service/planItemService_test.ts` - Fake client pattern ile test refactor