### PR TITLE
chore(service-layer): add contract README + refactor validation + align tests

### DIFF
--- a/engine/src/services/README.md
+++ b/engine/src/services/README.md
@@ -1,0 +1,23 @@
+# Service Layer Standards
+
+This directory contains the business logic and RPC wrappers for the Application Engine.
+
+## Contract
+All services must adhere to the following contract:
+
+1.  **Input Validation**: All public methods must validate inputs *before* making any RPC calls.
+    *   Use private helper methods for validation logic (e.g., `validateItem`).
+    *   Throw standard `Error` objects for invalid inputs.
+2.  **RPC Interaction**: Services should wrap Supabase RPC calls.
+    *   Do not expose raw PostgREST responses directly if possible; return typed data or primitives.
+3.  **Error Handling**:
+    *   Catch RPC errors and re-throw them with a standardized prefix format: `RPC <method_name> failed: <message>`.
+
+## Testing
+- Tests must use `FakeSupabaseClient` (State-based test double) instead of loose mocks.
+- Tests must be deterministic (no dependency on system clock or random without seed).
+- Tests must not make real network calls during unit testing.
+
+## File Naming
+- Services: `camelCaseService.ts` (e.g., `planItemService.ts`)
+- Tests: `tests/service/camelCaseService_test.ts`

--- a/engine/src/services/planItemService.ts
+++ b/engine/src/services/planItemService.ts
@@ -19,10 +19,7 @@ export class PlanItemService {
      * @returns The UUID of the inserted/updated plan item
      */
     async insertPlanItem(item: PlanItem): Promise<string> {
-        // Validate inputs (Basic boundary validation)
-        if (!item.plan_id) throw new Error("plan_id is required");
-        if (!item.meal_id) throw new Error("meal_id is required");
-        if (!item.meal_type) throw new Error("meal_type is required");
+        this.validateItem(item);
 
         const { data, error } = await this.supabase.rpc("insert_plan_item", {
             p_plan_id: item.plan_id,
@@ -39,5 +36,16 @@ export class PlanItemService {
         }
 
         return data as string;
+    }
+
+    private validateItem(item: PlanItem): void {
+        const errors: string[] = [];
+        if (!item.plan_id) errors.push("plan_id is required");
+        if (!item.meal_id) errors.push("meal_id is required");
+        if (!item.meal_type) errors.push("meal_type is required");
+
+        if (errors.length > 0) {
+            throw new Error(`Validation failed: ${errors.join(", ")}`);
+        }
     }
 }

--- a/tests/service/planItemService_test.ts
+++ b/tests/service/planItemService_test.ts
@@ -53,7 +53,7 @@ Deno.test("PlanItemService - insertPlanItem - with FakeClient", async (t) => {
                 });
             },
             Error,
-            "plan_id is required"
+            "Validation failed: plan_id is required"
         );
     });
 


### PR DESCRIPTION
## NEDEN

Bu PR, service layer pattern'ı standartlaştırır:
- Contract README eklendi (validation + error handling + testing kuralları)
- planItemService.ts'de validation refactor edildi (validateItem private method)
- Test error message formatı align edildi

## Değişen Dosyalar

- `engine/src/services/README.md` - Service Layer Standards dokümantasyonu
- `engine/src/services/planItemService.ts` - validateItem helper ile validation refactor
- `tests/service/planItemService_test.ts` - Error message format güncellemesi